### PR TITLE
Remove usenames option from xcolor.

### DIFF
--- a/tufte-common.def
+++ b/tufte-common.def
@@ -821,7 +821,7 @@
 
 %%
 % Color
-\RequirePackage[usenames,dvipsnames,svgnames]{xcolor}% load before bidi
+\RequirePackage[dvipsnames,svgnames]{xcolor}% load before bidi
 
 %%
 % Load the bidi package if instructed to do so.  This package must be loaded


### PR DESCRIPTION
According to the `xcolor` release notes, the `override`, `usenames`, `nodvipsnames` options and `\xdefinecolor` command are no longer needed, as of 2004/07/04 (v2.00).