### PR TITLE
Issue 87: compatibility with listings, subfigure and subcaption packages

### DIFF
--- a/tufte-common.def
+++ b/tufte-common.def
@@ -1241,16 +1241,13 @@
     \ifthenelse{\equal{#1}{b}\OR\equal{#1}{B}}%
       {\renewcommand{\floatalignment}{b}\@tufte@float@debug{Presumed position: [bottom]}}%
       {\renewcommand{\floatalignment}{t}\@tufte@float@debug{Presumed position: [top]}}%
-    % Capture the contents of the \caption and \label commands to use later
+    % Capture the contents of the \caption command to use later
     \global\let\@tufte@orig@caption\caption%
     \global\let\@tufte@orig@label\label%
-    \renewcommand{\caption}{\optparams{\@tufte@caption}{[][0pt]}}%
-    \renewcommand{\label}[1]{\@tufte@label{##1}}%
-    % Handle subfigure package compatibility
-    \ifthenelse{\boolean{@tufte@packages@subfigure}}{%
-      % don't move the label while inside a \subfigure or \subtable command
-      \global\let\label\@tufte@orig@label%
-    }{}% subfigure package is not loaded
+    \renewcommand{\caption}{%
+      % Now also capture the contents of the \label command to use later
+      \let\label\@tufte@label%
+      \optparams{\@tufte@caption}{[][0pt]}}%
     \@tufte@orig@float{#2}[#1]%
     \ifthenelse{\boolean{@tufte@float@star}}%
       {\setlength{\@tufte@float@contents@width}{\@tufte@fullwidth}}%
@@ -1908,18 +1905,6 @@
         {There are already 78 float slots allocated. Try using \string\FloatBarrier\space or \string\clearpage\space to place some floats before creating more.}
     }%
   }%
-}
-
-
-%%
-% Detect if the subfigure package has been loaded
-
-\newboolean{@tufte@packages@subfigure}
-\setboolean{@tufte@packages@subfigure}{false}
-\AtBeginDocument{%
-  \@ifpackageloaded{subfigure}
-    {\gsetboolean{@tufte@packages@subfigure}{true}}
-    {\gsetboolean{@tufte@packages@subfigure}{false}}%
 }
 
 


### PR DESCRIPTION
Redefine the `\label` command only after the `\caption` command, so that line lables in listings and labels in subfloats are retained. This requires that the float label is given after the caption (this is required anyway and not specific to this change) and that the caption and label are specified at the end of the float. Since the `tufte-latex` package implements its own caption placement irrespective of the position of the `\caption` command, this should not pose a problem.