### PR TITLE
Add class option 'baseclass' with argument.

### DIFF
--- a/sample-book.tex
+++ b/sample-book.tex
@@ -816,6 +816,8 @@ document class.  Therefore, you can pass any of the typical book
 options.  There are a few options that are specific to the
 \doccls{tufte-book} document class, however.
 
+The \doccls{book} document class can be replaced with a different base class by using the \docclsoptdef{baseclass} option. For example, the user may select the \smallcaps{KOMA-Script} class \doccls{scrbook} with \docclsoptdef{baseclass=scrbook}.
+
 The \docclsoptdef{a4paper} option will set the paper size to \smallcaps{A4} instead of
 the default \smallcaps{US} letter size.
 
@@ -929,7 +931,7 @@ sections or subsections, use the command:
   \doccmd{setcounter}\{secnumdepth\}\{0\}
 \end{docspec}
 
-The default \doccounter{secnumdepth} for the \TL document classes is $-1$.
+The default \doccounter{secnumdepth} for the \TL document classes is~$-1$.
 
 \begin{table}
   \footnotesize

--- a/tufte-book.cls
+++ b/tufte-book.cls
@@ -4,8 +4,9 @@
 
 %%
 % Declare we're tufte-book
-\newcommand{\@tufte@class}{book}% the base LaTeX class (defaults to the book style)
-\newcommand{\@tufte@pkgname}{tufte-book}% the name of the package (defaults to tufte-handout)
+\newcommand{\@tufte@class}{book}% the base LaTeX class
+% (defaults to the book style; override with 'baseclass' option)
+\newcommand{\@tufte@pkgname}{tufte-book}% the name of the package
 
 %%
 % Load the common style elements

--- a/tufte-common.def
+++ b/tufte-common.def
@@ -1713,7 +1713,7 @@
 % Format lists of figures/tables
 
 \renewcommand\listoffigures{%
-  \ifthenelse{\equal{\@tufte@class}{book}}%
+  \ifthenelse{\equal{\@tufte@pkgname}{tufte-book}}%
     {\chapter*{\listfigurename}}%
     {\section*{\listfigurename}}%
 %  \begin{fullwidth}%
@@ -1722,7 +1722,7 @@
 }
 
 \renewcommand\listoftables{%
-  \ifthenelse{\equal{\@tufte@class}{book}}%
+  \ifthenelse{\equal{\@tufte@pkgname}{tufte-book}}%
     {\chapter*{\listtablename}}%
     {\section*{\listtablename}}%
 %  \begin{fullwidth}%
@@ -1784,7 +1784,7 @@
 
 \RequirePackage{multicol}
 \renewenvironment{theindex}{%
-  \ifthenelse{\equal{\@tufte@class}{book}}%
+  \ifthenelse{\equal{\@tufte@pkgname}{tufte-book}}%
     {\chapter{\indexname}}%
     {\section*{\indexname}}%
   \begin{fullwidth}%

--- a/tufte-common.def
+++ b/tufte-common.def
@@ -20,6 +20,12 @@
 \newcommand{\@tufte@debug@info@noline}[1]{\ifthenelse{\boolean{@tufte@debug}}{\@tufte@info@noline{#1}}{}}
 
 %%
+% `baseclass' option -- allow user-selected base document class,
+% e.g., `baseclass=scrartcl' instead of `article'
+% or `baseclass=scrbook' instead of `book'.
+\DeclareOptionX[tufte]<common>{baseclass}{\renewcommand{\@tufte@class}{#1}}
+
+%%
 % `debug' option -- provides more information in the .log file for use in
 % troubleshooting problems
 \newboolean{@tufte@debug}
@@ -1503,6 +1509,7 @@
 \newcommand{\PrintTufteSettings}{%
   \typeout{-------------------- Tufte-LaTeX settings ----------}
   \typeout{Class: \@tufte@pkgname}
+  \typeout{[baseclass]: \@tufte@class}
   \typeout{}
   \typeout{Class options:}
   \typeoutbool{a4paper}{@tufte@afourpaper}

--- a/tufte-handout.cls
+++ b/tufte-handout.cls
@@ -4,8 +4,9 @@
 
 %%
 % Declare we're tufte-handout
-\newcommand{\@tufte@class}{article}% the base LaTeX class (defaults to the article/handout style)
-\newcommand{\@tufte@pkgname}{tufte-handout}% the name of the package (defaults to tufte-handout)
+\newcommand{\@tufte@class}{article}% the base LaTeX class
+% (defaults to the article/handout style; override with 'baseclass' option)
+\newcommand{\@tufte@pkgname}{tufte-handout}% the name of the package
 
 %%
 % Load the common style elements


### PR DESCRIPTION
Enable executive (user) override of the base document class. For example, the user may want to use `scrartcl` instead of `article` or `scrbook` instead of `book`. Now she can choose `baseclass=scrartcl` or `baseclass=scrbook` as class option.