### PR TITLE
respect nofonts class option

### DIFF
--- a/tufte-common.def
+++ b/tufte-common.def
@@ -302,7 +302,7 @@
   \setboolean{@tufte@luatex}{false}
 }
 
-\ifthenelse{\boolean{@tufte@luatex}}{%
+\ifthenelse{\boolean{@tufte@loadfonts}\AND\boolean{@tufte@luatex}}{%
   \RequirePackage{fontspec}
   \RequirePackage[osf,sc]{mathpazo}
   \setmainfont[Renderer=Basic, Numbers=OldStyle, Scale = 1.0]{TeX Gyre Pagella}


### PR DESCRIPTION
LuaLatex: Fonts are loaded even, the class option `nofonts` is set.